### PR TITLE
Fix #1: Discard autojump

### DIFF
--- a/game.cc
+++ b/game.cc
@@ -44,10 +44,9 @@ void Game::keyReleaseEvent(QKeyEvent* keyEvent) {
 void Game::timeoutSlot() {
     if (jumpPressed) {
         _player.jump();
-        jumpPressed = false;
     }
 
-    _player.update();
+    _player.update(jumpPressed);
     _obstacleManager.update(_player.y());
 
     if (_player.y() > 0.5f)

--- a/player.cc
+++ b/player.cc
@@ -28,7 +28,7 @@ void Player::jump() {
     _speedY = INITIAL_SPEED;
 }
 
-void Player::update() {
+void Player::update(bool& jumpPressed) {
     if (_jumping) {
         _speedY -= SPEED_LOWER;
 
@@ -40,8 +40,10 @@ void Player::update() {
             _x -= SPEED_X;
 
         // Collision
-        if ((_x - _w / 2.0f <= LEFT_SIDE) || (_x + _w / 2.0f >= RIGHT_SIDE))
+        if ((_x - _w / 2.0f <= LEFT_SIDE) || (_x + _w / 2.0f >= RIGHT_SIDE)) {
             afterJump();
+            jumpPressed = false; /* to avoid autojump */
+        }
     } else {
         if (_y > 0.0f)
             _y -= 0.005;

--- a/player.h
+++ b/player.h
@@ -8,7 +8,7 @@ public:
     Player();
     void jump();
 
-    void update();
+    void update(bool& jumpPressed);
 
     float x() { return _x; }
     float y() { return _y; }


### PR DESCRIPTION
- Discard key autorepeat.
- Automatically consider the space key released
  when jump initiated.
